### PR TITLE
fix bug: half of bottom nucleotide pair cut off from svg

### DIFF
--- a/static/app/self/self.js
+++ b/static/app/self/self.js
@@ -16,7 +16,7 @@ angular.module('genome.self', [])
     speed = 0.01,
     torsion = 0.2,
     x = d3.scale.linear().range([20, w - 20]),
-    y = d3.scale.linear().range([h, 20]),
+    y = d3.scale.linear().range([h-100, 20]),
     z = d3.scale.linear().range([20, 5]);
       /**
         * This block will append the built svg elements to the "body" of the HTML


### PR DESCRIPTION
resolve #121 

Self.js in the fills array options:
`"y = d3.scale.linear().range([h-100, 20])"`

Previously it was set to 
`y = d3.scale.linear().range([h, 20]),`

The y values control the top and bottom of the helix within the svg container. The first element in array "h-100" is the distance from bottom of svg. The second element "20" is the distance from the top of the svg for the first helix pair to display.

I set it to -100 so that we can see the entire helix when we load the page... 
Later when we hard-code the rest of the SNPS, we could have a number be dynamically generated so that it becomes the height of the main SVG element and then we could use it to calculate the y-range to distribute each helix pair evenly